### PR TITLE
Fix console warnings + Small tweaks from Zak (part 1 :D)

### DIFF
--- a/src/Components/Flow.tsx
+++ b/src/Components/Flow.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactFlow, {
-  MiniMap,
-  Controls,
   Background,
   useNodesState,
   useEdgesState,
@@ -53,7 +51,7 @@ export function Flow() {
       const { x, y } = nodes[3].position;
       reactFlow.setCenter(x, y, { duration: 1500, zoom: 0.6 });
     }
-  }, [reactFlow]);
+  }, [reactFlow, nodes]);
 
   return (
     <>

--- a/src/Components/Modal.tsx
+++ b/src/Components/Modal.tsx
@@ -11,7 +11,6 @@ interface Props {
 
 const Modal = ({ modalData, hideModal, isModalOpen }: Props) => {
   const modalRef = useRef(null);
-
   const closeModal = (e: React.MouseEvent) => {
     if (modalRef.current === e.target) {
       hideModal();
@@ -49,13 +48,15 @@ const Modal = ({ modalData, hideModal, isModalOpen }: Props) => {
           <div className="DescriptionContent flex flex-col justify-start items-start leading-5 text-white space-y-4 mt-4">
             <h1 className="TitleText font-bold text-2xl text-teal-600">{modalData.label}</h1>
             <p>{modalData.overview}</p>
-            <p>{modalData.description}</p>
+            <p className="whitespace-pre-wrap">{modalData.description}</p>
           </div>
-          <a href={modalData.link} target="_blank" rel="noreferrer" className="LinkOfButton mb-2 w-[50%]">
-            <button className="ChallengeButton bg-teal-600 text-white rounded-md hover:bg-teal-700 w-full h-full mb-4">
-              Take the Challenge
-            </button>
-          </a>
+          <div className="text-center">
+            <a href={modalData.link} target="_blank" rel="noreferrer" className="LinkOfButton mb-2">
+              <button className="ChallengeButton bg-teal-600 text-white rounded-md hover:bg-teal-700 w-full h-full mb-4  w-[50%]">
+                Take the Challenge
+              </button>
+            </a>
+          </div>
         </div>
         <div
           className="ExitingX cursor-pointer absolute top-2 right-2 w-[2%] h-[2%] text-2xl p-0 z-10"

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -6,7 +6,7 @@ export const dataNodes: DataNode[] = [
     id: 1,
     title: "Challenge 0 🎨 Simple NFT",
     overview: "Create a simple NFT to learn basics of scaffold-eth.",
-    description: " This is a long description.  This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description.",
+    description: "This is a long description.\n\nThis is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description. This is a long description.",
     link: "https://speedrunethereum.com/challenge/simple-nft-example",
     image: "https://speedrunethereum.com/assets/0.png",
     dependencies: [2],


### PR DESCRIPTION
Fixed React console warnings:

![warnings](https://user-images.githubusercontent.com/2486142/199633137-2e69e390-be74-416c-998b-fac90a76d90d.png)

> Center the button in the bottom of the modal.
+
> How in the world do you do a <br> in the descriptions in the modal to have separate paragraphs?

Now you can use "\n" in the description and it will respected.

![pre](https://user-images.githubusercontent.com/2486142/199633167-8154b39c-d0f7-48d3-ac0c-071a54d794aa.png)

> 

